### PR TITLE
Title & Tags Enhancement, Upgrades bug fix

### DIFF
--- a/automatic/lyricsfinder/lyricsfinder.nuspec
+++ b/automatic/lyricsfinder/lyricsfinder.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>lyricsfinder</id>
     <version>1.5.1</version>
-    <title>Lyrics Finder</title>
+    <title>Lyrics Finder (Portable) (Trial)</title>
     <authors>MediaHuman</authors>
     <projectUrl>https://www.mediahuman.com/lyrics-finder</projectUrl>
     <docsUrl>https://www.mediahuman.com/lyrics-finder/guides/</docsUrl>
     <iconUrl>https://cdn.rawgit.com/valentind44/chocolatey-packages/6ac421ae/icons/lyricsfinder.png</iconUrl>
     <copyright>© MediaHuman</copyright>
-    <tags>lyrics finder tag mp3</tags>
+    <tags>lyrics finder tag mp3 portable trial</tags>
     <summary>Automatically search and add lyrics to tracks in your music collection</summary>
     <description>MediaHuman Lyrics Finder is a free software application, which can help you find and add missing lyrics (song text) to all songs in your music library. It's a safe operation because the app doesn't overwrite lyrics you've already had.
 

--- a/automatic/lyricsfinder/tools/chocolateyinstall.ps1
+++ b/automatic/lyricsfinder/tools/chocolateyinstall.ps1
@@ -17,7 +17,7 @@ innounp -x "$webFilePath" -d"$toolsDir" -y -q
 
 Remove-Item -path "$toolsDir\{tmp}" -recurse
 Remove-Item -path "$toolsDir\install_script.iss"
-Move-Item -Path "$toolsDir\{app}\*" -Destination "$toolsDir" -Force
+Move-Item -Path "$toolsDir\{app}\*" -Destination "$toolsDir" -Force -ErrorAction SilentlyContinue
 Remove-Item -path "$toolsDir\{app}"
 
 Install-ChocolateyShortcut -shortcutFilePath "$($env:ProgramData)\Microsoft\Windows\Start Menu\Lyrics Finder.lnk" -targetPath "$toolsDir\LyricsFinder.exe"


### PR DESCRIPTION
update description and tags

Since this is extracted and not installed, it really should be described as thus.

---------------------------------------

fixes upgrades

Currently upgrades fail with:
ERROR: The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: Cannot create a file when that file already exists.

This happens because Move-Item can not overwrite directories, only files, and gives the above error when asked to do such. (Dumb huh?) So having the Move-Item ignore this error fixes the problem.